### PR TITLE
fix AA layout adding dot at the beginning of string

### DIFF
--- a/src/scripts/duuune.coffee
+++ b/src/scripts/duuune.coffee
@@ -12,6 +12,7 @@
 module.exports = (robot) ->
   robot.hear /(ドゥーン|duu+ne|doo+ne)/i, (msg) ->
     msg.send """
+.
 　　　∧_∧ 
 　　(　･ω･)　ﾄﾞｩｰﾝ!! 
 　　|　⊃⊃ 


### PR DESCRIPTION
Leading spaces are deleted in slack...
So, how about adding a dot at the beginning of the characters.
